### PR TITLE
Fix the email array

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -251,6 +251,7 @@ class auth_plugin_casattras extends auth_plugin_base {
         foreach ($this->userfields as $field) {
             $casfield = $this->config->{"field_map_$field"};
 	    if (!empty($casfield) && !empty($casattras[$casfield])) {
+		// There can be multiple emails stored in LDAP. Use the first one.
 		if('email' === $field && is_array($casattras[$casfield])){
 			$casattras[$casfield] = array_shift($casattras[$casfield]);
 		}

--- a/auth.php
+++ b/auth.php
@@ -250,7 +250,10 @@ class auth_plugin_casattras extends auth_plugin_base {
 
         foreach ($this->userfields as $field) {
             $casfield = $this->config->{"field_map_$field"};
-            if (!empty($casfield) && !empty($casattras[$casfield])) {
+	    if (!empty($casfield) && !empty($casattras[$casfield])) {
+		if('email' === $field && is_array($casattras[$casfield])){
+			$casattras[$casfield] = array_shift($casattras[$casfield]);
+		}
                 $moodleattras[$field] = $casattras[$casfield];
             }
         }


### PR DESCRIPTION
Use only the first item of the email array. Fixes an issue in case user has multiple emails stored in LDAP.